### PR TITLE
Fixes: Link after github abusix -> xarf move.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 xarf is a free and open community project. It is an email format to report different types of network abuse incidents to network owners.
 
-Please see the [xarf-specification_0.2.md](https://github.com/abusix/xarf-specification/blob/master/xarf-specification_0.2.md). Schemes are available in the [xarf-schemata](https://github.com/abusix/xarf-schemata) github repository.
+Please see the [xarf-specification_0.2.md](./xarf-specification_0.2.md). Schemes are available in the [xarf-schemata](https://github.com/xarf/xarf-schemata) github repository.
 
 Visit the [xarf.org](http://xarf.org) website for further information.

--- a/xarf-specification_0.2.md
+++ b/xarf-specification_0.2.md
@@ -232,17 +232,17 @@ Please see the [definition of Information Sharing Traffic Light Protocol](http:/
 ### `X-XARF: PLAIN`
 A default plain message with a 3rd MIME part will look like:
 
-![X-XARF PLAIN example](https://raw.github.com/abusix/xarf-specification/master/examples/v0.2/xarf-specification_0.2.x-xarf-plain.png)
+![X-XARF PLAIN example](https://raw.github.com/xarf/xarf-specification/master/examples/v0.2/xarf-specification_0.2.x-xarf-plain.png)
 
 ### `X-XARF: SECURE`
 A digitally PGP/MIME signed message with its RFC 2822 container is illustrated by the following image:
 
-![X-XARF SECURE example with PGP/MIME signed RFC 2822 container](https://raw.github.com/abusix/xarf-specification/master/examples/v0.2/xarf-specification_0.2.x-xarf-secure-rfc822-container-pgpmime-signed.png)
+![X-XARF SECURE example with PGP/MIME signed RFC 2822 container](https://raw.github.com/xarf/xarf-specification/master/examples/v0.2/xarf-specification_0.2.x-xarf-secure-rfc822-container-pgpmime-signed.png)
 
 ### `X-XARF: BULK`
 An example bulk message including two plain reports in RFC 2822 containers is represented by the following image:
 
-![X-XARF BULK example containing two PLAIN messages](https://raw.github.com/abusix/xarf-specification/master/examples/v0.2/xarf-specification_0.2.x-xarf-bulk-rfc822-container.png)
+![X-XARF BULK example containing two PLAIN messages](https://raw.github.com/xarf/xarf-specification/master/examples/v0.2/xarf-specification_0.2.x-xarf-bulk-rfc822-container.png)
 
 ***
 


### PR DESCRIPTION
Fixed links in the readme and the 0.2 spec.
Note: maybe relative links to the images in the 0.2 specs would be even better.